### PR TITLE
operation_M2: Add M2 selective removal support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
@@ -70,6 +76,13 @@
 
     <build>
         <finalName>Raven-Processor</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/src/main/java/us/deans/raven/processor/M2Result.java
+++ b/src/main/java/us/deans/raven/processor/M2Result.java
@@ -1,0 +1,21 @@
+package us.deans.raven.processor;
+
+public class M2Result {
+
+    private final long uploadId;
+    private final long postsDeleted;
+    private final boolean success;
+    private final String message;
+
+    public M2Result(long uploadId, long postsDeleted, boolean success, String message) {
+        this.uploadId = uploadId;
+        this.postsDeleted = postsDeleted;
+        this.success = success;
+        this.message = message;
+    }
+
+    public long getUploadId()     { return uploadId; }
+    public long getPostsDeleted() { return postsDeleted; }
+    public boolean isSuccess()    { return success; }
+    public String getMessage()    { return message; }
+}

--- a/src/main/java/us/deans/raven/processor/M2Service.java
+++ b/src/main/java/us/deans/raven/processor/M2Service.java
@@ -1,0 +1,45 @@
+package us.deans.raven.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Operation M2 — Selective Removal.
+ *
+ * Given a list of upload_id values, cascades deletion through both databases:
+ * MongoDB posts are deleted first, then the MariaDB upload record.
+ * A failure on one upload is logged and reported but does not abort the rest.
+ */
+public class M2Service {
+
+    private static final Logger log = LoggerFactory.getLogger(M2Service.class);
+
+    private final MongoDao mongoDao;
+    private final Maria_DAO mariaDao;
+
+    public M2Service(MongoDao mongoDao, Maria_DAO mariaDao) {
+        this.mongoDao = mongoDao;
+        this.mariaDao = mariaDao;
+    }
+
+    public List<M2Result> execute(List<Long> uploadIds) {
+        List<M2Result> results = new ArrayList<>();
+
+        for (long uploadId : uploadIds) {
+            try {
+                long postsDeleted = mongoDao.deletePosts(uploadId);
+                mariaDao.deleteUpload(uploadId);
+                log.info("M2: removed upload_id={} ({} posts deleted)", uploadId, postsDeleted);
+                results.add(new M2Result(uploadId, postsDeleted, true, null));
+            } catch (Exception e) {
+                log.error("M2: failed for upload_id={} — {}", uploadId, e.getMessage(), e);
+                results.add(new M2Result(uploadId, 0, false, e.getMessage()));
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/test/java/M2ServiceTest.java
+++ b/src/test/java/M2ServiceTest.java
@@ -1,0 +1,98 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import us.deans.raven.processor.M2Result;
+import us.deans.raven.processor.M2Service;
+import us.deans.raven.processor.Maria_DAO;
+import us.deans.raven.processor.MongoDao;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class M2ServiceTest {
+
+    @Mock
+    MongoDao mongoDao;
+
+    @Mock
+    Maria_DAO mariaDao;
+
+    M2Service service;
+
+    @BeforeEach
+    void setUp() {
+        service = new M2Service(mongoDao, mariaDao);
+    }
+
+    @Test
+    void singleUpload_success() throws Exception {
+        when(mongoDao.deletePosts(301L)).thenReturn(482L);
+
+        List<M2Result> results = service.execute(List.of(301L));
+
+        assertEquals(1, results.size());
+        M2Result r = results.get(0);
+        assertEquals(301L, r.getUploadId());
+        assertEquals(482L, r.getPostsDeleted());
+        assertTrue(r.isSuccess());
+        assertNull(r.getMessage());
+
+        verify(mongoDao).deletePosts(301L);
+        verify(mariaDao).deleteUpload(301L);
+    }
+
+    @Test
+    void multipleUploads_allSucceed() throws Exception {
+        when(mongoDao.deletePosts(301L)).thenReturn(10L);
+        when(mongoDao.deletePosts(302L)).thenReturn(20L);
+
+        List<M2Result> results = service.execute(List.of(301L, 302L));
+
+        assertEquals(2, results.size());
+        assertTrue(results.get(0).isSuccess());
+        assertTrue(results.get(1).isSuccess());
+        assertEquals(10L, results.get(0).getPostsDeleted());
+        assertEquals(20L, results.get(1).getPostsDeleted());
+    }
+
+    @Test
+    void mongoFailure_reportedAndRemainingUploadsStillProcessed() throws Exception {
+        when(mongoDao.deletePosts(301L)).thenThrow(new RuntimeException("connection timeout"));
+        when(mongoDao.deletePosts(302L)).thenReturn(5L);
+
+        List<M2Result> results = service.execute(List.of(301L, 302L));
+
+        assertEquals(2, results.size());
+
+        M2Result failed = results.get(0);
+        assertEquals(301L, failed.getUploadId());
+        assertFalse(failed.isSuccess());
+        assertEquals(0L, failed.getPostsDeleted());
+        assertTrue(failed.getMessage().contains("connection timeout"));
+
+        M2Result succeeded = results.get(1);
+        assertEquals(302L, succeeded.getUploadId());
+        assertTrue(succeeded.isSuccess());
+        assertEquals(5L, succeeded.getPostsDeleted());
+
+        verify(mariaDao, never()).deleteUpload(301L);
+        verify(mariaDao).deleteUpload(302L);
+    }
+
+    @Test
+    void mariaFailure_reportedAndRemainingUploadsStillProcessed() throws Exception {
+        when(mongoDao.deletePosts(301L)).thenReturn(10L);
+        doThrow(new RuntimeException("DB error")).when(mariaDao).deleteUpload(301L);
+        when(mongoDao.deletePosts(302L)).thenReturn(5L);
+
+        List<M2Result> results = service.execute(List.of(301L, 302L));
+
+        assertFalse(results.get(0).isSuccess());
+        assertTrue(results.get(1).isSuccess());
+    }
+}


### PR DESCRIPTION
## Summary
- Add M2-related files to support selective upload removal operation

## Test plan
- [ ] Build and install Raven-Processor JAR to local .m2
- [ ] Rebuild Raven-Jobs against updated Processor
- [ ] Test M2 operation via operation-M2.sh with a list of upload IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)