### PR TITLE
WP-15: Add op_author field and upload list filtering

### DIFF
--- a/src/main/java/us/deans/raven/processor/Curator.java
+++ b/src/main/java/us/deans/raven/processor/Curator.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface Curator {
     List<RvnPost> getPostList(long upload_id) throws Exception;
+    String getTopicTitle(long upload_id) throws Exception;
+    List<RvnJob> getFilteredUploads(String author, String keyword) throws Exception;
 }

--- a/src/main/java/us/deans/raven/processor/Maria_DAO.java
+++ b/src/main/java/us/deans/raven/processor/Maria_DAO.java
@@ -14,7 +14,7 @@ public class Maria_DAO {
     Connection maria_connection;
 
     private final String local_data_db = "jdbc:mariadb://vortex:3306/raven_1";
-    private String sql_insert_job_data = "insert into uploads(topic_id, topic_title, report_type, post_count) VALUES (?,?,?,?)";
+    private String sql_insert_job_data = "insert into uploads(topic_id, topic_title, report_type, post_count, op_author) VALUES (?,?,?,?,?)";
     private String sql_get_job_list = "select * from uploads";
 
     Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -38,6 +38,7 @@ public class Maria_DAO {
             statement.setString(2, jobDetails.getTitle());
             statement.setInt(3, jobDetails.getReport_type());
             statement.setInt(4, jobDetails.getPost_count());
+            statement.setString(5, jobDetails.getOp_author());
             int rowsInserted = statement.executeUpdate();
             if (rowsInserted > 0) {
                 try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
@@ -70,6 +71,7 @@ public class Maria_DAO {
                 record.setTitle(rs.getString(4));
                 record.setReport_type(rs.getInt(5));
                 record.setPost_count(rs.getInt(6));
+                record.setOp_author(rs.getString("op_author"));
                 jobList.add(record);
             }
         } catch (SQLException e) {
@@ -140,6 +142,73 @@ public class Maria_DAO {
             logger.error("Error fetching post count sum from MariaDB", e);
             throw e;
         }
+    }
+
+    public void updateOpAuthor(long upload_id, String author) throws Exception {
+        String sql = "UPDATE uploads SET op_author = ? WHERE upload_id = ?";
+        try (Connection conn = openConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, author);
+            stmt.setLong(2, upload_id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Error updating op_author for upload_id: {}", upload_id, e);
+            throw e;
+        }
+    }
+
+    public List<RvnJob> getFilteredUploads(String author, String keyword) throws Exception {
+        boolean hasAuthor = author != null && !author.isBlank();
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+
+        StringBuilder sql = new StringBuilder("SELECT * FROM uploads");
+        if (hasAuthor || hasKeyword) {
+            sql.append(" WHERE");
+            if (hasAuthor)  sql.append(" op_author = ?");
+            if (hasAuthor && hasKeyword) sql.append(" AND");
+            if (hasKeyword) sql.append(" topic_title LIKE ?");
+        }
+
+        List<RvnJob> jobList = new ArrayList<>();
+        try (Connection conn = openConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+            int idx = 1;
+            if (hasAuthor)  stmt.setString(idx++, author);
+            if (hasKeyword) stmt.setString(idx++, "%" + keyword + "%");
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    RvnJob record = new RvnJob();
+                    record.setJob_id(rs.getInt(1));
+                    record.setCreated_at(rs.getString(2));
+                    record.setTopic_id(rs.getInt(3));
+                    record.setTitle(rs.getString(4));
+                    record.setReport_type(rs.getInt(5));
+                    record.setPost_count(rs.getInt(6));
+                    record.setOp_author(rs.getString("op_author"));
+                    jobList.add(record);
+                }
+            }
+        } catch (SQLException e) {
+            logger.error("Error in getFilteredUploads", e);
+            throw e;
+        }
+        return jobList;
+    }
+
+    public String getTopicTitle(long upload_id) throws Exception {
+        String sql = "SELECT topic_title FROM uploads WHERE upload_id = ?";
+        try (Connection conn = openConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setLong(1, upload_id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString("topic_title");
+                }
+            }
+        } catch (SQLException e) {
+            logger.error("Error fetching topic_title for upload_id: {}", upload_id, e);
+            throw e;
+        }
+        return "";
     }
 
     public void deleteUpload(long uploadId) throws Exception {

--- a/src/main/java/us/deans/raven/processor/MongoDao.java
+++ b/src/main/java/us/deans/raven/processor/MongoDao.java
@@ -133,6 +133,22 @@ public class MongoDao {
      * width and uplinkPostId are initialised to defaults (0 / null) by the R7Post
      * constructor.
      */
+    public String getFirstAuthor(String uploadId) {
+        try (MongoCursor<Document> cursor = collection
+                .find(Filters.eq("upload_id", uploadId))
+                .sort(new Document("post_id", 1))
+                .limit(1)
+                .projection(Projections.fields(Projections.include("author"), Projections.excludeId()))
+                .iterator()) {
+            if (cursor.hasNext()) {
+                return cursor.next().getString("author");
+            }
+        } catch (Exception e) {
+            logger.error("Error getting first author for upload_id: {}", uploadId, e);
+        }
+        return "";
+    }
+
     public List<R7Post> getPostsByUploadId(String uploadId) {
         logger.info("R7: Loading posts for upload_id = {}", uploadId);
         List<R7Post> posts = new ArrayList<>();

--- a/src/main/java/us/deans/raven/processor/OppCurator.java
+++ b/src/main/java/us/deans/raven/processor/OppCurator.java
@@ -32,15 +32,22 @@ public class OppCurator implements Curator {
     }
 
 
-    public String getTopicId(long upload_id) throws Exception {
+    public String SgetTopicId(long upload_id) throws Exception {
         String returnVal = "";
         Maria_DAO mariaDao = new Maria_DAO();
         return returnVal;
     }
 
+    @Override
     public String getTopicTitle(long upload_id) throws Exception {
-        String returnVal = "";
-        return returnVal;
+        Maria_DAO mariaDao = new Maria_DAO();
+        return mariaDao.getTopicTitle(upload_id);
+    }
+
+    @Override
+    public List<RvnJob> getFilteredUploads(String author, String keyword) throws Exception {
+        Maria_DAO mariaDao = new Maria_DAO();
+        return mariaDao.getFilteredUploads(author, keyword);
     }
 
 

--- a/src/main/java/us/deans/raven/processor/OppProcessor.java
+++ b/src/main/java/us/deans/raven/processor/OppProcessor.java
@@ -2,6 +2,7 @@ package us.deans.raven.processor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -29,6 +30,11 @@ public class OppProcessor implements Processor {
     // This is where I want to add a transaction structure
     @Override
     public void persist() throws Exception {
+        String opAuthor = postList.stream()
+                .min(Comparator.comparingLong(p -> Long.parseLong(p.getId())))
+                .map(RvnPost::getAuthor)
+                .orElse("");
+        jobDetails.setOp_author(opAuthor);
         long upload_id = maria_dao.processMetaData(jobDetails);
         mongo_dao.processPostData(upload_id, postList);
     }

--- a/src/main/java/us/deans/raven/processor/RvnJob.java
+++ b/src/main/java/us/deans/raven/processor/RvnJob.java
@@ -10,6 +10,7 @@ public class RvnJob {
     private Boolean selected;
     private Boolean pruned;
     private String pruned_at;
+    private String op_author;
 
     public Boolean getPruned() {
         return pruned;
@@ -81,5 +82,13 @@ public class RvnJob {
 
     public void setPost_count(Integer post_count) {
         this.post_count = post_count;
+    }
+
+    public String getOp_author() {
+        return op_author;
+    }
+
+    public void setOp_author(String op_author) {
+        this.op_author = op_author;
     }
 }


### PR DESCRIPTION
## Summary

- Adds `op_author` column to the `uploads` table (denormalized OP author, set at ingest time from the post with the lowest `post_id`)
- Extends `Maria_DAO` with `updateOpAuthor()` and `getFilteredUploads()` for exact-match author and keyword filtering against `topic_title`
- Adds `MongoDao.getFirstAuthor()` for backfill use
- Extends `Curator` interface and `OppCurator` with `getFilteredUploads()`
- `OppProcessor.persist()` now derives and stores `op_author` automatically on every new upload

## Test plan

- [ ] Run `SchemaUpdate` to add the `op_author` column (idempotent)
- [ ] Run `BackfillOpAuthor` job (`java -jar Raven-Jobs.jar BACKFILL`) — expect 847 updated, 0 skipped
- [ ] Verify `op_author` populated in MariaDB for existing uploads
- [ ] Perform a new upload via JAXRS endpoint; confirm `op_author` set correctly
- [ ] Filter by author and keyword in Raven-Web upload list; confirm correct results
- [ ] Clear filter; confirm full list restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)