### PR TITLE
FE-20: Add getFilteredPosts() for audit filter

### DIFF
--- a/src/main/java/us/deans/raven/processor/Curator.java
+++ b/src/main/java/us/deans/raven/processor/Curator.java
@@ -6,4 +6,5 @@ public interface Curator {
     List<RvnPost> getPostList(long upload_id) throws Exception;
     String getTopicTitle(long upload_id) throws Exception;
     List<RvnJob> getFilteredUploads(String author, String keyword) throws Exception;
+    List<RvnPost> getFilteredPosts(long uploadId, String author, String keyword) throws Exception;
 }

--- a/src/main/java/us/deans/raven/processor/MongoDao.java
+++ b/src/main/java/us/deans/raven/processor/MongoDao.java
@@ -6,6 +6,7 @@ import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,6 +148,42 @@ public class MongoDao {
             logger.error("Error getting first author for upload_id: {}", uploadId, e);
         }
         return "";
+    }
+
+    public List<RvnPost> getFilteredPosts(long uploadId, String author, String keyword) {
+        String strUploadId = String.valueOf(uploadId);
+        List<Bson> filters = new ArrayList<>();
+        filters.add(Filters.eq("upload_id", strUploadId));
+
+        if (author != null && !author.trim().isEmpty()) {
+            filters.add(Filters.eq("author", author.trim()));
+        }
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            filters.add(Filters.regex("text", keyword.trim(), "i"));
+        }
+
+        List<RvnPost> postList = new ArrayList<>();
+        try (MongoCursor<Document> cursor = collection
+                .find(Filters.and(filters))
+                .sort(new Document("post_id", 1))
+                .iterator()) {
+            while (cursor.hasNext()) {
+                Document doc = cursor.next();
+                RvnPost post = new RvnPost();
+                post.setId(doc.getString("post_id"));
+                post.setAuthor(doc.getString("author"));
+                post.setHead(doc.getString("head"));
+                post.setLink(doc.getString("link"));
+                post.setText(doc.getString("text"));
+                post.setHtml(doc.getString("html"));
+                post.setTopic_id(doc.getString("topic_id"));
+                post.setUpload_id(uploadId);
+                postList.add(post);
+            }
+        } catch (Exception e) {
+            logger.error("Error filtering posts for upload_id={}: {}", strUploadId, e.getMessage());
+        }
+        return postList;
     }
 
     public List<R7Post> getPostsByUploadId(String uploadId) {

--- a/src/main/java/us/deans/raven/processor/OppCurator.java
+++ b/src/main/java/us/deans/raven/processor/OppCurator.java
@@ -50,6 +50,16 @@ public class OppCurator implements Curator {
         return mariaDao.getFilteredUploads(author, keyword);
     }
 
+    @Override
+    public List<RvnPost> getFilteredPosts(long uploadId, String author, String keyword) throws Exception {
+        MongoDao mongoDao = new MongoDao();
+        try {
+            return mongoDao.getFilteredPosts(uploadId, author, keyword);
+        } finally {
+            mongoDao.close();
+        }
+    }
+
 
 
 }


### PR DESCRIPTION
## Summary

- Adds `MongoDao.getFilteredPosts()` — filters posts by `upload_id` plus optional author (exact match) and keyword (case-insensitive regex on `text` field), with AND logic when both are set, ordered by `post_id` ASC
- Adds `getFilteredPosts()` to `Curator` interface
- Implements in `OppCurator`, delegating to `MongoDao`

## Test plan

- [ ] Filter by author only — confirm only posts by that author are returned
- [ ] Filter by keyword only — confirm case-insensitive text match works
- [ ] Filter by both — confirm AND logic (author + keyword)
- [ ] Clear filter — confirm full post list is restored
- [ ] Empty filters — confirm all posts returned (no filtering applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)