### PR TITLE
PI-04: Add charset=utf8mb4 to MariaDB connection URL

### DIFF
--- a/src/main/java/us/deans/raven/processor/Maria_DAO.java
+++ b/src/main/java/us/deans/raven/processor/Maria_DAO.java
@@ -13,7 +13,7 @@ public class Maria_DAO {
     private long upload_id = 0;
     Connection maria_connection;
 
-    private final String local_data_db = "jdbc:mariadb://vortex:3306/raven_1";
+    private final String local_data_db = "jdbc:mariadb://vortex:3306/raven_1?charset=utf8mb4";
     private String sql_insert_job_data = "insert into uploads(topic_id, topic_title, report_type, post_count, op_author) VALUES (?,?,?,?,?)";
     private String sql_get_job_list = "select * from uploads";
 


### PR DESCRIPTION
## Summary
- Appends `?charset=utf8mb4` to the hardcoded connection URL in `Maria_DAO.java`
- Ensures MariaDB Connector/J 3.4.1 negotiates utf8mb4 on every connection, consistent with the schema migration in the Raven-Jobs PI-04 PR
- Without this, the driver and server may fall back to a narrower charset regardless of the schema setting

## Test plan
- [ ] Rebuild Raven-Processor and redeploy Raven-JAXRS.war and Raven-Web.war (already done)
- [ ] Upload a topic with emoji in the title and confirm it persists without error (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)