### PR TITLE
FE-21: Add findPostById() for Post Analyzer view

### DIFF
--- a/src/main/java/us/deans/raven/processor/Curator.java
+++ b/src/main/java/us/deans/raven/processor/Curator.java
@@ -1,10 +1,12 @@
 package us.deans.raven.processor;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface Curator {
     List<RvnPost> getPostList(long upload_id) throws Exception;
     String getTopicTitle(long upload_id) throws Exception;
     List<RvnJob> getFilteredUploads(String author, String keyword) throws Exception;
     List<RvnPost> getFilteredPosts(long uploadId, String author, String keyword) throws Exception;
+    Optional<RvnPost> findPostById(String postId) throws Exception;
 }

--- a/src/main/java/us/deans/raven/processor/MongoDao.java
+++ b/src/main/java/us/deans/raven/processor/MongoDao.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class MongoDao {
@@ -184,6 +185,37 @@ public class MongoDao {
             logger.error("Error filtering posts for upload_id={}: {}", strUploadId, e.getMessage());
         }
         return postList;
+    }
+
+    /**
+     * FE-21: Finds a single post by post_id, for resolving which upload a post
+     * belongs to. Does not assume uniqueness — if Operation M3 has not run
+     * recently, the same post_id can theoretically exist under more than one
+     * upload_id. Takes the first match (by natural Mongo ordering) and logs a
+     * warning so the discrepancy is visible without failing the caller.
+     */
+    public Optional<RvnPost> findPostById(String postId) {
+        List<Document> matches = collection.find(Filters.eq("post_id", postId)).into(new ArrayList<>());
+
+        if (matches.isEmpty()) {
+            return Optional.empty();
+        }
+        if (matches.size() > 1) {
+            logger.warn("Duplicate post_id {} found across {} documents — Operation M3 may be overdue. Using first match.",
+                    postId, matches.size());
+        }
+
+        Document doc = matches.get(0);
+        RvnPost post = new RvnPost();
+        post.setId(doc.getString("post_id"));
+        post.setAuthor(doc.getString("author"));
+        post.setHead(doc.getString("head"));
+        post.setLink(doc.getString("link"));
+        post.setText(doc.getString("text"));
+        post.setHtml(doc.getString("html"));
+        post.setTopic_id(doc.getString("topic_id"));
+        post.setUpload_id(Long.parseLong(doc.getString("upload_id")));
+        return Optional.of(post);
     }
 
     public List<R7Post> getPostsByUploadId(String uploadId) {

--- a/src/main/java/us/deans/raven/processor/OppCurator.java
+++ b/src/main/java/us/deans/raven/processor/OppCurator.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *  This class is the curator for managing the uploaded data and supports the JSF application
@@ -60,6 +61,14 @@ public class OppCurator implements Curator {
         }
     }
 
-
+    @Override
+    public Optional<RvnPost> findPostById(String postId) throws Exception {
+        MongoDao mongoDao = new MongoDao();
+        try {
+            return mongoDao.findPostById(postId);
+        } finally {
+            mongoDao.close();
+        }
+    }
 
 }


### PR DESCRIPTION
## Summary
- Adds `MongoDao.findPostById()` / `Curator.findPostById()` / `OppCurator.findPostById()` to resolve a `post_id` to its containing post (including `upload_id`), for the new Post Analyzer view in Raven-Jakarta-Web.
- Does not assume `post_id` uniqueness — logs a warning and returns the first match if Operation M3 hasn't run recently enough to guarantee it.

## Test plan
- [x] `mvn clean install` — 6/6 tests passing
- [x] Verified end-to-end against live data via the paired Raven-Jakarta-Web PR (FE-21-Analyzer-View)