### PR TITLE
PI-25: Fix log message to reference Operation M1 instead of M3

### DIFF
--- a/src/main/java/us/deans/raven/processor/MongoDao.java
+++ b/src/main/java/us/deans/raven/processor/MongoDao.java
@@ -189,7 +189,7 @@ public class MongoDao {
 
     /**
      * FE-21: Finds a single post by post_id, for resolving which upload a post
-     * belongs to. Does not assume uniqueness — if Operation M3 has not run
+     * belongs to. Does not assume uniqueness — if Operation M1 has not run
      * recently, the same post_id can theoretically exist under more than one
      * upload_id. Takes the first match (by natural Mongo ordering) and logs a
      * warning so the discrepancy is visible without failing the caller.
@@ -201,7 +201,7 @@ public class MongoDao {
             return Optional.empty();
         }
         if (matches.size() > 1) {
-            logger.warn("Duplicate post_id {} found across {} documents — Operation M3 may be overdue. Using first match.",
+            logger.warn("Duplicate post_id {} found across {} documents — Operation M1 may be overdue. Using first match.",
                     postId, matches.size());
         }
 

--- a/src/main/java/us/deans/raven/processor/OppCurator.java
+++ b/src/main/java/us/deans/raven/processor/OppCurator.java
@@ -33,7 +33,7 @@ public class OppCurator implements Curator {
     }
 
 
-    public String SgetTopicId(long upload_id) throws Exception {
+    public String getTopicId(long upload_id) throws Exception {
         String returnVal = "";
         Maria_DAO mariaDao = new Maria_DAO();
         return returnVal;


### PR DESCRIPTION
## Summary
- `MongoDao.findPostById()` logged a warning pointing at Operation M3 (Daily Verification, detect-and-alert only) when duplicate `post_id`s are found — it should point at Operation M1 (Remove Duplicates), the operation that actually sweeps duplicates. Carried over from the FE-21 spec's original mistake; docs were corrected earlier (see raven-docs `Work/Issues.md` PI-25), this is the matching code fix.
- Also renames `OppCurator.SgetTopicId()` → `getTopicId()` (NI-18) — stray `S` prefix was a naming accident, method unused elsewhere.

## Test plan
- [ ] Trigger a duplicate `post_id` lookup via the Analyzer view and confirm the server log now cites Operation M1
- [ ] Confirm `getTopicId()` compiles and is called correctly wherever `OppCurator` is wired in